### PR TITLE
Don't fail when not using ActiveRecord

### DIFF
--- a/lib/watir/rspec/active_record_shared_connection.rb
+++ b/lib/watir/rspec/active_record_shared_connection.rb
@@ -1,16 +1,20 @@
 RSpec.configuration.before(:suite) do
-  # Allow RSpec specs to use transactional fixtures when using Watir. 
-  #
-  # Tip from http://blog.plataformatec.com.br/2011/12/three-tips-to-improve-the-performance-of-your-test-suite/
-  class ::ActiveRecord::Base
-    mattr_accessor :shared_connection
-    @@shared_connection = nil
+  begin
+    # Allow RSpec specs to use transactional fixtures when using Watir. 
+    #
+    # Tip from http://blog.plataformatec.com.br/2011/12/three-tips-to-improve-the-performance-of-your-test-suite/
+    class ::ActiveRecord::Base
+      mattr_accessor :shared_connection
+      @@shared_connection = nil
 
-    def self.connection
-      @@shared_connection || retrieve_connection
+      def self.connection
+        @@shared_connection || retrieve_connection
+      end
     end
-  end
 
-  # Forces all threads to share the same connection. 
-  ::ActiveRecord::Base.shared_connection = ::ActiveRecord::Base.connection
+    # Forces all threads to share the same connection. 
+    ::ActiveRecord::Base.shared_connection = ::ActiveRecord::Base.connection
+  rescue ActiveRecord::ConnectionNotEstablished => e
+    puts "#{e} -- ActiveRecord not in use?"
+  end
 end


### PR DESCRIPTION
This patch prevents watir-rspec from failing when ActiveRecord has been removed (for instance, when using Mongoid).
