### PR TITLE
non-trivial requirements needs to be clearly presented

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,9 @@ end
 And add these lines to your spec\_helper.rb file:
 
 ````ruby
+require "watir/rspec"
+require "rspec-expectations"
+
 RSpec.configure do |config|
   # Add Watir::RSpec::HtmlFormatter to get links to the screenshots, html and
   # all other files created during the failing examples.


### PR DESCRIPTION
I had some troubles using setting up this gem

requiring "watir/rspec" instead of "watir-rspec" was not obvious to me

and then I was getting 

```
uninitialized constant RSpec::Matchers::BuiltIn (NameError)
```

and requiring "rspec-expectations" fixes it :)
