### PR TITLE
file_path discards description argument

### DIFF
--- a/lib/watir/rspec.rb
+++ b/lib/watir/rspec.rb
@@ -10,7 +10,7 @@ module Watir
       # @return [String] Absolute path for the unique file name.
       # @raise [RuntimeError] when {Watir::RSpec::HtmlFormatter} is not in use.
       def file_path(file_name, description=nil)
-        formatter.file_path(file_name, description=nil)
+        formatter.file_path(file_name, description)
       end
 
       # @private


### PR DESCRIPTION
The Watir::RSpec.file_path method is discarding the description argument. This prevents the user from customizing the link text.