### PR TITLE
fix parameter passing for blocks when using method missing

### DIFF
--- a/lib/watir/rspec/helper.rb
+++ b/lib/watir/rspec/helper.rb
@@ -22,7 +22,7 @@ module Watir
           Helper.module_eval %Q[
             def #{name}(*args)
               if block_given?
-                browser.send(:#{name}, *args) {yield}
+                browser.send(:#{name}, *args, &Proc.new)
               else
                 browser.send(:#{name}, *args)
               end
@@ -30,7 +30,7 @@ module Watir
           ]
 
           if block_given?
-            self.send(name, *args) {yield}
+            self.send(name, *args, &Proc.new)
           else
             self.send(name, *args)
           end
@@ -38,6 +38,7 @@ module Watir
           super
         end
       end
+
 
       # make sure that using method 'p' will be invoked on browser
       # and not Kernel

--- a/spec/watir/rspec/helper_spec.rb
+++ b/spec/watir/rspec/helper_spec.rb
@@ -35,7 +35,7 @@ describe Watir::RSpec::Helper do
       expect do
         self.not_existing_method
       end.to raise_error(NoMethodError)
-      expect(described_class).not_to be_method_defined  :not_existing_method
+      expect(described_class).not_to be_method_defined :not_existing_method
     end
 
     it "adds browser methods to the helper" do
@@ -52,5 +52,36 @@ describe Watir::RSpec::Helper do
     expect(described_class).not_to receive(:method_missing)
 
     expect(p).to eql "#p"
+  end
+
+  context "Block parameter for browser method" do
+    before :each do
+      @browser = double("browser")
+    end
+
+    it "block content is propagated to browser method when method is first called" do
+      expect(@browser).to receive(:window).with(:title => "my_window") { |&block| expect(block.call).to be == "my block content" }
+      # expect(described_class).to receive(:method_missing)
+      window(:title => "my_window") { "my block content" }
+    end
+
+    it "block content is propagated to browser method when method was already called" do
+      expect(@browser).to receive(:window).with(:title => "my_window") { |&block| expect(block.call).to be == "my block content" }.twice
+      # expect(described_class).to receive(:method_missing)
+      window(:title => "my_window") { "my block content" }
+      # expect(described_class).not_to receive(:method_missing)
+      window(:title => "my_window") { "my block content" }
+    end
+
+    it "Correct number of block parameters are properly propagated to browser method when method is first called" do
+      expect(@browser).to receive(:window).with(:title => "my_window").and_yield("first block parameter content", "second block parameter content")
+      expect(window(:title => "my_window") { |parameter_1, parameter_2| parameter_1 + " & " + parameter_2 }).to be == "first block parameter content & second block parameter content"
+    end
+
+    it "Correct number of block parameters are properly propagated to browser method when method is first called" do
+      expect(@browser).to receive(:window).with(:title => "my_window").and_yield("first block parameter content", "second block parameter content").twice
+      expect(window(:title => "my_window") { |parameter_1, parameter_2| parameter_1 + " & " + parameter_2 }).to be == "first block parameter content & second block parameter content"
+      expect(window(:title => "my_window") { |parameter_1, parameter_2| parameter_1 + " & " + parameter_2 }).to be == "first block parameter content & second block parameter content"
+    end
   end
 end


### PR DESCRIPTION
parameters passed to a block of a browser method were lost in the previous implementation:
- used &Proc.new instead of &block  --> see http://mudge.name/2011/01/26/passing-blocks-in-ruby-without-block.html
- added related rspec tests

I left 3 commented lines in the rspec test which could make the test more accurate as they seem to fail the test when uncommented. I can't figured out why the method_missing is not called. Perhaps you can assist me here?
